### PR TITLE
Fixed Facebook crash and GCP duplicate dialogs

### DIFF
--- a/wings-facebook/src/main/java/com/groundupworks/wings/facebook/FacebookEndpoint.java
+++ b/wings-facebook/src/main/java/com/groundupworks/wings/facebook/FacebookEndpoint.java
@@ -374,6 +374,9 @@ public class FacebookEndpoint extends WingsEndpoint {
             if (fragment == null) {
                 permissionsRequest = new NewPermissionsRequest(activity, publishPermissions);
             } else {
+                if (fragment.getActivity() == null) {
+                    return false;
+                }
                 permissionsRequest = new NewPermissionsRequest(fragment, publishPermissions);
             }
             permissionsRequest.setDefaultAudience(SessionDefaultAudience.EVERYONE);

--- a/wings-gcp/src/main/AndroidManifest.xml
+++ b/wings-gcp/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
 
         <activity
             android:name=".GoogleCloudPrintSettingsActivity"
-            android:label="@string/wings_gcp__settings__label" />
+            android:label="@string/wings_gcp__settings__label"
+            android:finishOnTaskLaunch="true" />
     </application>
 </manifest>

--- a/wings-gcp/src/main/java/com/groundupworks/wings/gcp/GoogleCloudPrintEndpoint.java
+++ b/wings-gcp/src/main/java/com/groundupworks/wings/gcp/GoogleCloudPrintEndpoint.java
@@ -113,7 +113,6 @@ public class GoogleCloudPrintEndpoint extends WingsEndpoint {
         editor.remove(mContext.getString(R.string.wings_gcp__token));
         editor.apply();
 
-
         // Emit link state change event.
         notifyLinkStateChanged(new LinkEvent(false));
 

--- a/wings-gcp/src/main/java/com/groundupworks/wings/gcp/GoogleCloudPrintSettingsActivity.java
+++ b/wings-gcp/src/main/java/com/groundupworks/wings/gcp/GoogleCloudPrintSettingsActivity.java
@@ -194,9 +194,7 @@ public class GoogleCloudPrintSettingsActivity extends Activity implements
     @Override
     protected void onStart() {
         super.onStart();
-        if (mOauthObservable == null) {
-            mAccountSelectionHelper.selectUserAccount(ACCOUNT_TYPE);
-        }
+        mAccountSelectionHelper.selectUserAccount(ACCOUNT_TYPE);
     }
 
     @Override


### PR DESCRIPTION
Fixed Facebook crash and GCP duplicate dialogs when backgrounding during linking
